### PR TITLE
Add ability to create subindexes

### DIFF
--- a/oak/src/acorn.rs
+++ b/oak/src/acorn.rs
@@ -23,12 +23,13 @@ impl AcornHnswIndex {
         let dimensionality = i32::try_from(dataset.get_dimensionality())
             .expect("dimensionality should not be greater than 2,147,483,647");
 
+        let metadata = dataset.get_metadata();
         let mut index = ffi::new_index_acorn(
             dimensionality,
             options.m,
             options.gamma,
             options.m_beta,
-            &dataset.get_metadata(),
+            metadata.as_ref(),
         );
         debug!(
             "Constructed index with dimensionality: {dimensionality}, m: {}, gamma: {}, m_beta: {}",

--- a/oak/src/bin/example.rs
+++ b/oak/src/bin/example.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         m_beta: 64,
     };
 
-    let _ = dataset.initialize(&opts);
+    let _ = dataset.build_index(&opts);
     info!("Seed index constructed.");
 
     let dimensionality = dataset.get_dimensionality() as usize;

--- a/oak/src/bin/example_router.rs
+++ b/oak/src/bin/example_router.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use clap::Parser;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use slog_scope::info;
+use thiserror::Error;
+
+use oak::dataset::{Dataset, OakIndexOptions};
+use oak::fvecs::{FlattenedVecs, FvecsDataset};
+use oak::predicate::PredicateQuery;
+use oak::stubs::generate_random_vector;
+
+#[derive(Error, Debug)]
+pub enum ExampleError {
+    #[error("Generic error")]
+    GenericError,
+    #[error("Failed to start server: {0}")]
+    ServerStartError(String),
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(short, long, required(true))]
+    dataset: String,
+}
+
+fn main() -> Result<()> {
+    let log = ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Debug,
+    }
+    .to_logger("oak-logger")
+    .map_err(|e| ExampleError::ServerStartError(e.to_string()))?;
+
+    let _guard = slog_scope::set_global_logger(log.clone());
+
+    let args = Args::parse();
+
+    let mut dataset = FvecsDataset::new(args.dataset)?;
+    info!("Dataset loaded from disk.");
+
+    let opts = OakIndexOptions {
+        gamma: 1,
+        m: 32,
+        m_beta: 64,
+    };
+
+    let _ = dataset.build_index(&opts);
+    info!("Seed index constructed.");
+
+    let query = PredicateQuery::new(5);
+
+    let mut subindex = dataset.view(&query);
+    let _ = subindex.build_index(&opts);
+    info!("Subindex as view constructed.");
+
+    let dimensionality = dataset.get_dimensionality() as usize;
+    assert_eq!(dimensionality, subindex.get_dimensionality() as usize);
+
+    info!("Constructing random vector to query with {dimensionality} dimensions");
+    let query_vector = FlattenedVecs {
+        dimensionality,
+        data: generate_random_vector(dimensionality),
+    };
+    let topk = 10;
+    let num_queries = query_vector.len();
+
+    info!("Searching for {topk} similar vectors for {num_queries} random query, where attr is equal to 5...");
+
+    let result = dataset.search(&query_vector, &Some(query), topk);
+
+    info!("Got results.");
+    info!("{:?}", result);
+
+    Ok(())
+}

--- a/oak/src/bin/example_router.rs
+++ b/oak/src/bin/example_router.rs
@@ -59,6 +59,9 @@ fn main() -> Result<()> {
     let dimensionality = dataset.get_dimensionality() as usize;
     assert_eq!(dimensionality, subdataset.get_dimensionality() as usize);
 
+    // Experiments
+    // --------=--
+    //
     info!("Constructing random vector to query with {dimensionality} dimensions");
     let query_vector = FlattenedVecs {
         dimensionality,

--- a/oak/src/bin/example_router.rs
+++ b/oak/src/bin/example_router.rs
@@ -3,8 +3,10 @@ use clap::Parser;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
 use slog_scope::info;
+use std::time::Instant;
 use thiserror::Error;
 
+use oak::bitmask::Bitmask;
 use oak::dataset::{Dataset, OakIndexOptions};
 use oak::fvecs::{FlattenedVecs, FvecsDataset};
 use oak::predicate::PredicateQuery;
@@ -50,12 +52,12 @@ fn main() -> Result<()> {
 
     let query = PredicateQuery::new(5);
 
-    let mut subindex = dataset.view(&query);
-    let _ = subindex.build_index(&opts);
+    let mut subdataset = dataset.view(&query);
+    let _ = subdataset.build_index(&opts);
     info!("Subindex as view constructed.");
 
     let dimensionality = dataset.get_dimensionality() as usize;
-    assert_eq!(dimensionality, subindex.get_dimensionality() as usize);
+    assert_eq!(dimensionality, subdataset.get_dimensionality() as usize);
 
     info!("Constructing random vector to query with {dimensionality} dimensions");
     let query_vector = FlattenedVecs {
@@ -65,12 +67,35 @@ fn main() -> Result<()> {
     let topk = 10;
     let num_queries = query_vector.len();
 
-    info!("Searching for {topk} similar vectors for {num_queries} random query, where attr is equal to 5...");
+    let mask_main = Bitmask::new(&query, &dataset);
+    let mask_sub = Bitmask::new_full(&subdataset);
 
-    let result = dataset.search(&query_vector, &Some(query), topk);
+    info!("Searching full dataset for {topk} similar vectors for {num_queries} random query , where attr is equal to 5...");
 
-    info!("Got results.");
-    info!("{:?}", result);
+    let big_start = Instant::now();
+    let big_result = dataset.search_with_bitmask(&query_vector, mask_main, topk);
+    let big_end = big_start.elapsed();
+
+    info!("Searching dataset partition for {topk} similar vectors for {num_queries} random query, with no predicate as we know all vectors match...");
+
+    let small_start = Instant::now();
+    let small_result = dataset.search_with_bitmask(&query_vector, mask_sub, topk);
+    let small_end = small_start.elapsed();
+
+    let big_mean_distance = big_result.unwrap()[0]
+        .iter()
+        .fold(0, |acc, (distance, _)| acc + distance)
+        / topk;
+
+    info!("Results from full search:");
+    info!("Mean distance: {:?}", big_mean_distance);
+
+    let small_mean_distance = small_result.unwrap()[0]
+        .iter()
+        .fold(0, |acc, (distance, _)| acc + distance)
+        / topk;
+    info!("Results from sub search:");
+    info!("Mean distance: {:?}", small_mean_distance);
 
     Ok(())
 }

--- a/oak/src/bitmask.rs
+++ b/oak/src/bitmask.rs
@@ -39,9 +39,9 @@ impl Bitmask {
         Self { map, bitcount }
     }
 
-    pub fn new_empty<D: Dataset>(dataset: &D) -> Self {
+    pub fn new_full<D: Dataset>(dataset: &D) -> Self {
         let map = vec![true as i8; dataset.len()];
-        let bitcount = 0;
+        let bitcount = 1;
         Self { map, bitcount }
     }
 

--- a/oak/src/bitmask.rs
+++ b/oak/src/bitmask.rs
@@ -1,0 +1,75 @@
+use crate::dataset::Dataset;
+use crate::predicate::{PredicateOp, PredicateQuery};
+use core::ffi::c_char;
+
+pub struct Bitmask {
+    pub map: Vec<i8>,
+    pub bitcount: usize,
+}
+
+impl Bitmask {
+    /// 'Serializes' a query as a filter map, which will allow it to be passed across FFI to the
+    /// `search` function. A filter map is specific to a dataset, as it is of length (nq * N),
+    /// where nq is the number of queries in the map, and N is the number of vectors in the
+    /// dataset. A value of 1 in the bitmap represents that the search query matches with the
+    /// vector at that index in the dataset, and a value of 0 that it doesn't.
+    ///
+    /// If an attribute matching the `lhs` of the query does not exist in the dataset, then an
+    /// error will be raised.
+    pub fn new<D: Dataset>(pq: &PredicateQuery, dataset: &D) -> Self {
+        let ds_len = dataset.len();
+        let mut map: Vec<c_char> = vec![0; ds_len];
+
+        assert_eq!(dataset.get_metadata().len(), map.len());
+
+        let rhs: i32 = i32::from(&pq.rhs);
+        let on_bit: c_char = 1;
+        let mut bitcount: usize = 0;
+
+        for (i, xq) in dataset.get_metadata().iter().enumerate() {
+            let bit = match pq.op {
+                PredicateOp::Equals => (xq == &rhs) as c_char,
+            };
+            if bit.eq(&on_bit) {
+                bitcount += 1;
+            }
+            map[i] = bit;
+        }
+
+        Self { map, bitcount }
+    }
+
+    pub fn new_empty<D: Dataset>(dataset: &D) -> Self {
+        let map = vec![true as i8; dataset.len()];
+        let bitcount = 0;
+        Self { map, bitcount }
+    }
+
+    pub fn bitcount(&self) -> usize {
+        self.bitcount
+    }
+}
+
+impl From<Bitmask> for Vec<i8> {
+    fn from(mask: Bitmask) -> Self {
+        mask.map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let dataset = FvecsDataset::new("data/sift_query".to_string()).unwrap();
+        let pq = PredicateQuery {
+            op: PredicateOp::Equals,
+            rhs: PredicateRhs::Number(10),
+        };
+
+        let bitmap = Bitmask::new(&pq, &dataset);
+        let one = 1 as c_char;
+        assert!(bitmap.map.contains(&one));
+    }
+}

--- a/oak/src/bitmask.rs
+++ b/oak/src/bitmask.rs
@@ -26,7 +26,7 @@ impl Bitmask {
         let on_bit: c_char = 1;
         let mut bitcount: usize = 0;
 
-        for (i, xq) in dataset.get_metadata().iter().enumerate() {
+        for (i, xq) in dataset.get_metadata().as_ref().iter().enumerate() {
             let bit = match pq.op {
                 PredicateOp::Equals => (xq == &rhs) as c_char,
             };

--- a/oak/src/dataset.rs
+++ b/oak/src/dataset.rs
@@ -1,6 +1,6 @@
+use crate::bitmask::Bitmask;
 use crate::fvecs::{FlattenedVecs, Fvec};
 use crate::predicate::PredicateQuery;
-// use tracing::info;
 
 use anyhow::Result;
 use thiserror::Error;
@@ -37,7 +37,12 @@ pub type TopKSearchResult = Vec<SimilaritySearchResult>;
 // A batch of items with type `TopKSearchResult`.
 pub type TopKSearchResultBatch = Vec<TopKSearchResult>;
 
-/// These parameters are currently essentially ACORN parameters, taken from https://github.com/csirianni/ACORN/blob/main/README.md
+/// The type in which the attributes for hybrid search are notated. At the moment the assumed
+/// constraint is that there is at most one attribute per vector, and it is always an i32.
+pub type HybridSearchMetadata = Vec<i32>;
+
+/// These parameters are currently essentially ACORN parameters, taken from
+/// https://github.com/csirianni/ACORN/blob/main/README.md
 pub struct OakIndexOptions {
     /// Degree bound for traversed nodes during ACORN search
     pub m: i32,
@@ -59,28 +64,38 @@ impl Default for OakIndexOptions {
 }
 
 /// Trait for a dataset of vectors.
-/// Note that this must be `Sized` in order that the constructor can return a Result.
-pub trait Dataset: Sized {
-    /// Create a new dataset, loading all fvecs into memory. The `fname` should represent a
-    /// filename that corresponds to both a "{fname}.fvecs" that contains the vectors, and a
-    /// "{fname}.csv" that contains the attributes (over which predicates can be constructed) for
-    /// those vectors. Each row in the CSV corresponds to the vector at the same index in the fvecs
-    /// file, and each column represents an attribute on that vector.
-    fn new(fname: String) -> Result<Self>;
-    /// Initialize the index with the vectors from the dataset.
-    fn initialize(&mut self, opts: &OakIndexOptions) -> Result<(), ConstructionError>;
+pub trait Dataset {
     /// Provide the number of vectors that have been added to the dataset.
     fn len(&self) -> usize;
+
     /// Provide the dimensionality of the vectors in the dataset.
     fn get_dimensionality(&self) -> usize;
+
     /// Returns data in dataset. Fails if full dataset doesn't fit in memory.
     fn get_data(&self) -> Result<Vec<Fvec>>;
+
+    /// Get the metadata that represents the attributes over the vectors (for hybrid search).
+    fn get_metadata(&self) -> &HybridSearchMetadata;
+
+    /// Build the index associated with this dataset. If an index has not been built, all search
+    /// methods will throw an error.
+    fn build_index(&mut self, opts: &OakIndexOptions) -> Result<(), ConstructionError>;
+
     /// Takes a Vec<Fvec> and returns a Vec<Vec<(usize, f32)>>, whereby each inner Vec<(usize, f32)> is an array
     /// of tuples in which t[0] is the index of the resthe `topk` vectors returned from the result.
     fn search(
         &self,
         query_vectors: &FlattenedVecs,
         predicate_query: &Option<PredicateQuery>,
+        topk: usize,
+    ) -> Result<Vec<TopKSearchResult>, SearchableError>;
+
+    /// Takes a Vec<Fvec> and returns a Vec<Vec<(usize, f32)>>, whereby each inner Vec<(usize, f32)> is an array
+    /// of tuples in which t[0] is the index of the resthe `topk` vectors returned from the result.
+    fn search_with_bitmask(
+        &self,
+        query_vectors: &FlattenedVecs,
+        bitmask: Bitmask,
         topk: usize,
     ) -> Result<Vec<TopKSearchResult>, SearchableError>;
 }

--- a/oak/src/dataset.rs
+++ b/oak/src/dataset.rs
@@ -80,33 +80,6 @@ impl AsRef<Vec<i32>> for HybridSearchMetadata {
     }
 }
 
-// impl IntoIterator for HybridSearchMetadata {
-//     type Item = &i32;
-//     type IntoIter = HybridSearchMetadataIntoIterator;
-//
-//     fn into_iter(self) -> Self::IntoIter {
-//         HybridSearchMetadataIntoIterator {
-//             data: self,
-//             index: 0,
-//         }
-//     }
-// }
-//
-// struct HybridSearchMetadataIntoIterator {
-//     data: HybridSearchMetadata,
-//     index: usize,
-// }
-//
-// impl Iterator for HybridSearchMetadataIntoIterator {
-//     type Item = &i32;
-//
-//     fn next(&mut self) -> Option<Self::Item> {
-//         let result = self.data.attrs.get(self.index);
-//         self.index += 1;
-//         result
-//     }
-// }
-
 /// These parameters are currently essentially ACORN parameters, taken from
 /// https://github.com/csirianni/ACORN/blob/main/README.md
 pub struct OakIndexOptions {

--- a/oak/src/fvecs.rs
+++ b/oak/src/fvecs.rs
@@ -277,7 +277,7 @@ impl Dataset for FvecsDataset {
         debug!("fvecs dataset len: {}", self.len());
 
         let mut mask = match predicate_query {
-            None => Bitmask::new_empty(self),
+            None => Bitmask::new_full(self),
             Some(pq) => Bitmask::new(pq, self),
         };
 

--- a/oak/src/fvecs.rs
+++ b/oak/src/fvecs.rs
@@ -226,7 +226,9 @@ impl FvecsDataset {
             mask: Bitmask::new(pq, self),
             flat: None,
             index: None,
-            metadata: &self.metadata,
+            // TODO: this cannot just be this. It needs to be the filtered metadata
+            // metadata: &self.metadata,
+            metadata: unimplemented!(),
         }
     }
 }

--- a/oak/src/lib.rs
+++ b/oak/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod acorn;
+pub mod bitmask;
 pub mod dataset;
 pub mod fvecs;
 pub mod predicate;
+// pub mod router;
 pub mod stubs;
 
 #[cxx::bridge(namespace = "faiss")]

--- a/oak/src/router.rs
+++ b/oak/src/router.rs
@@ -1,0 +1,7 @@
+use crate::acorn::AcornHnswIndex;
+
+pub struct Router {
+    base_index: &AcornHnswIndex,
+}
+
+impl Router {}


### PR DESCRIPTION
Adds the ability to create subindexes over `FvecsDatasets` easily with bitmasks, and makes the `Bitmask` more explicit and easy to use.

Closes #32.