### PR TITLE
Fix unimplemented attributes filtering

### DIFF
--- a/oak/src/dataset.rs
+++ b/oak/src/dataset.rs
@@ -41,16 +41,15 @@ pub type TopKSearchResultBatch = Vec<TopKSearchResult>;
 /// constraint is that there is at most one attribute per vector, and it is always an i32.
 pub struct HybridSearchMetadata {
     attrs: Vec<i32>,
-    mask: Option<Bitmask>,
 }
 
 impl HybridSearchMetadata {
     pub fn new(attrs: Vec<i32>) -> Self {
-        Self { attrs, mask: None }
+        Self { attrs }
     }
 
-    pub fn new_from_bitmask(&self, mask: Bitmask) -> Self {
-        let filtered_attrs: Vec<i32> = self
+    pub fn new_from_bitmask(other: &Self, mask: &Bitmask) -> Self {
+        let filtered_attrs: Vec<i32> = other
             .attrs
             .iter()
             .zip(mask.map.iter())
@@ -65,7 +64,6 @@ impl HybridSearchMetadata {
 
         HybridSearchMetadata {
             attrs: filtered_attrs,
-            mask: Some(mask),
         }
     }
 

--- a/oak/src/fvecs.rs
+++ b/oak/src/fvecs.rs
@@ -221,14 +221,15 @@ impl FvecsDataset {
     }
 
     pub fn view(&self, pq: &PredicateQuery) -> FvecsDatasetPartition {
+        let mask = Bitmask::new(pq, self);
+        let metadata = HybridSearchMetadata::new_from_bitmask(&self.metadata, &mask);
+
         FvecsDatasetPartition {
             base: self,
-            mask: Bitmask::new(pq, self),
+            mask,
             flat: None,
             index: None,
-            // TODO: this cannot just be this. It needs to be the filtered metadata
-            // metadata: &self.metadata,
-            metadata: unimplemented!(),
+            metadata,
         }
     }
 }
@@ -316,7 +317,7 @@ pub struct FvecsDatasetPartition<'a> {
     /// original copy.
     flat: Option<FlattenedVecs>,
     /// The same with the metadata
-    metadata: &'a HybridSearchMetadata,
+    metadata: HybridSearchMetadata,
 }
 
 impl<'a> Dataset for FvecsDatasetPartition<'a> {


### PR DESCRIPTION
When creating a subindex, there was a lingering `unimplemented` wherein the new vec of filtered attributes was not yet created. There are probably smarter ways to do this without duplication; but the expense of creating new subindexes is not the point of our benchmarking in the next few days.