### PR TITLE
Create query routing mechanism

### DIFF
--- a/oak/benches/oak_benchmark.rs
+++ b/oak/benches/oak_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, Criterion, PlotConfiguration,
 };
-use oak::dataset::{Dataset, OakIndexOptions, TopKSearchResultBatch};
+use oak::dataset::{OakIndexOptions, SimilaritySearchable, TopKSearchResultBatch};
 use oak::fvecs::{FlattenedVecs, FvecsDataset};
 use oak::predicate::PredicateQuery;
 use oak::stubs::generate_random_vector;

--- a/oak/src/acorn.rs
+++ b/oak/src/acorn.rs
@@ -1,5 +1,5 @@
 use crate::dataset::{
-    ConstructionError, Dataset, OakIndexOptions, SearchableError, TopKSearchResult,
+    ConstructionError, OakIndexOptions, SearchableError, SimilaritySearchable, TopKSearchResult,
 };
 use crate::ffi;
 use crate::fvecs::{FlattenedVecs, FvecsDataset};
@@ -15,7 +15,7 @@ pub struct AcornHnswIndex {
 
 #[cfg(feature = "hnsw_faiss")]
 impl AcornHnswIndex {
-    pub fn new<D: Dataset>(
+    pub fn new<D: SimilaritySearchable>(
         dataset: &D,
         flattened: &FlattenedVecs,
         options: &OakIndexOptions,

--- a/oak/src/bin/example.rs
+++ b/oak/src/bin/example.rs
@@ -5,7 +5,7 @@ use dropshot::ConfigLoggingLevel;
 use slog_scope::info;
 use thiserror::Error;
 
-use oak::dataset::{Dataset, OakIndexOptions};
+use oak::dataset::{OakIndexOptions, SimilaritySearchable};
 use oak::fvecs::{FlattenedVecs, FvecsDataset};
 use oak::predicate::PredicateQuery;
 use oak::stubs::generate_random_vector;
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         m_beta: 64,
     };
 
-    let _ = dataset.build_index(&opts);
+    let _ = dataset.initialize(&opts);
     info!("Seed index constructed.");
 
     let dimensionality = dataset.get_dimensionality() as usize;

--- a/oak/src/bin/example_router.rs
+++ b/oak/src/bin/example_router.rs
@@ -2,14 +2,15 @@ use anyhow::Result;
 use clap::Parser;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
-use slog_scope::info;
+use slog_scope::{debug, info};
 use std::time::Instant;
 use thiserror::Error;
 
 use oak::bitmask::Bitmask;
-use oak::dataset::{Dataset, OakIndexOptions};
+use oak::dataset::{OakIndexOptions, SimilaritySearchable};
 use oak::fvecs::{FlattenedVecs, FvecsDataset};
 use oak::predicate::PredicateQuery;
+use oak::router::Router;
 use oak::stubs::generate_random_vector;
 
 #[derive(Error, Debug)]
@@ -47,13 +48,13 @@ fn main() -> Result<()> {
         m_beta: 64,
     };
 
-    let _ = dataset.build_index(&opts);
+    let _ = dataset.initialize(&opts);
     info!("Seed index constructed.");
 
     let query = PredicateQuery::new(5);
 
     let mut subdataset = dataset.view(&query);
-    let _ = subdataset.build_index(&opts);
+    let _ = subdataset.initialize(&opts);
     info!("Subindex as view constructed.");
 
     let dimensionality = dataset.get_dimensionality() as usize;
@@ -73,16 +74,27 @@ fn main() -> Result<()> {
     let mask_main = Bitmask::new(&query, &dataset);
     let mask_sub = Bitmask::new_full(&subdataset);
 
+    debug!(
+        "Mask main filled: {} / {}",
+        mask_main.bitcount(),
+        mask_main.capacity()
+    );
+    debug!(
+        "Mask sub filled: {} / {}",
+        mask_sub.bitcount(),
+        mask_sub.capacity()
+    );
+
     info!("Searching full dataset for {topk} similar vectors for {num_queries} random query , where attr is equal to 5...");
 
     let big_start = Instant::now();
-    let big_result = dataset.search_with_bitmask(&query_vector, mask_main, topk);
+    let big_result = dataset.search_with_bitmask(&query_vector, &mask_main, topk);
     let big_end = big_start.elapsed();
 
     info!("Searching dataset partition for {topk} similar vectors for {num_queries} random query, with no predicate as we know all vectors match...");
 
     let small_start = Instant::now();
-    let small_result = dataset.search_with_bitmask(&query_vector, mask_sub, topk);
+    let small_result = dataset.search_with_bitmask(&query_vector, &mask_sub, topk);
     let small_end = small_start.elapsed();
 
     let big_mean_distance = big_result.unwrap()[0]
@@ -92,6 +104,7 @@ fn main() -> Result<()> {
 
     info!("Results from full search:");
     info!("Mean distance: {:?}", big_mean_distance);
+    info!("Time taken: {:?}", big_end);
 
     let small_mean_distance = small_result.unwrap()[0]
         .iter()
@@ -99,6 +112,23 @@ fn main() -> Result<()> {
         / topk;
     info!("Results from sub search:");
     info!("Mean distance: {:?}", small_mean_distance);
+    info!("Time taken: {:?}", small_end);
+
+    // Using router
+    // ----------------------------
+    let router = Router::new(&dataset, vec![(&mask_sub, &subdataset)]);
+
+    let routed_start = Instant::now();
+    let routed_result = router.search_with_bitmask(&query_vector, &mask_main, topk);
+    let routed_end = routed_start.elapsed();
+
+    let routed_mean_distance = routed_result.unwrap()[0]
+        .iter()
+        .fold(0, |acc, (distance, _)| acc + distance)
+        / topk;
+    info!("Results from routed search:");
+    info!("Mean distance: {:?}", routed_mean_distance);
+    info!("Time taken: {:?}", routed_end);
 
     Ok(())
 }

--- a/oak/src/bin/example_router.rs
+++ b/oak/src/bin/example_router.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
 
     // Using router
     // ----------------------------
-    let router = Router::new(&dataset, vec![(&mask_sub, &subdataset)]);
+    let router = Router::new(&dataset, vec![(&mask_main, &subdataset)]);
 
     let routed_start = Instant::now();
     let routed_result = router.search_with_bitmask(&query_vector, &mask_main, topk);

--- a/oak/src/bin/server.rs
+++ b/oak/src/bin/server.rs
@@ -16,7 +16,7 @@ use slog_scope::{debug, info};
 use std::fs::OpenOptions;
 use thiserror::Error;
 
-use oak::dataset::{Dataset, OakIndexOptions};
+use oak::dataset::{OakIndexOptions, SimilaritySearchable};
 use oak::fvecs::{FlattenedVecs, FvecsDataset};
 use oak::predicate::PredicateQuery;
 // use oak::stubs::generate_random_vector;

--- a/oak/src/dataset.rs
+++ b/oak/src/dataset.rs
@@ -101,22 +101,19 @@ impl Default for OakIndexOptions {
 }
 
 /// Trait for a dataset of vectors.
-pub trait Dataset {
+pub trait SimilaritySearchable {
     /// Provide the number of vectors that have been added to the dataset.
     fn len(&self) -> usize;
 
     /// Provide the dimensionality of the vectors in the dataset.
     fn get_dimensionality(&self) -> usize;
 
-    /// Returns data in dataset. Fails if full dataset doesn't fit in memory.
-    fn get_data(&self) -> Result<Vec<Fvec>>;
-
     /// Get the metadata that represents the attributes over the vectors (for hybrid search).
     fn get_metadata(&self) -> &HybridSearchMetadata;
 
     /// Build the index associated with this dataset. If an index has not been built, all search
     /// methods will throw an error.
-    fn build_index(&mut self, opts: &OakIndexOptions) -> Result<(), ConstructionError>;
+    fn initialize(&mut self, opts: &OakIndexOptions) -> Result<(), ConstructionError>;
 
     /// Takes a Vec<Fvec> and returns a Vec<Vec<(usize, f32)>>, whereby each inner Vec<(usize, f32)> is an array
     /// of tuples in which t[0] is the index of the resthe `topk` vectors returned from the result.
@@ -132,7 +129,7 @@ pub trait Dataset {
     fn search_with_bitmask(
         &self,
         query_vectors: &FlattenedVecs,
-        bitmask: Bitmask,
+        bitmask: &Bitmask,
         topk: usize,
     ) -> Result<Vec<TopKSearchResult>, SearchableError>;
 }

--- a/oak/src/lib.rs
+++ b/oak/src/lib.rs
@@ -3,7 +3,7 @@ pub mod bitmask;
 pub mod dataset;
 pub mod fvecs;
 pub mod predicate;
-// pub mod router;
+pub mod router;
 pub mod stubs;
 
 #[cxx::bridge(namespace = "faiss")]
@@ -29,11 +29,13 @@ pub mod ffi {
 
         unsafe fn search_index(
             idx: &UniquePtr<IndexACORNFlat>,
-            n: i64,                     // number of query vectors
-            x: *const f32,              // pointer to an array of the query vectors
-            k: i64,                     // number of vectors to return for each query vector
+            n: i64,              // number of query vectors
+            x: *const f32,       // pointer to an array of the query vectors
+            k: i64,              // number of vectors to return for each query vector
             distances: *mut f32, // pointer to an array of (k*n) floats, each representing a distance of the result from the query vector
             labels: *mut i64, // pointer to an array of (k*n) indices, each representing the ID of the query vector in idx
+            // NOTE: this is mut because of the way that ACORN search is implemented in C++. It
+            // probably shouldn't be.
             filter_id_map: *mut c_char, // a bitmap of the IDs in the filter, an array of (n * N) bools, where N is the total number of vectors in the index, and a '1' represents that the vector at that index passes the predicate for that query.
         ) -> Result<()>;
     }

--- a/oak/src/predicate.rs
+++ b/oak/src/predicate.rs
@@ -1,4 +1,4 @@
-use crate::dataset::{Dataset, SearchableError};
+use crate::dataset::{SearchableError, SimilaritySearchable};
 use crate::fvecs::FvecsDataset;
 use anyhow::Result;
 

--- a/oak/src/router.rs
+++ b/oak/src/router.rs
@@ -1,7 +1,94 @@
 use crate::acorn::AcornHnswIndex;
+use crate::bitmask::Bitmask;
+use crate::dataset::SimilaritySearchable;
+use slog_scope::{debug, info};
 
-pub struct Router {
-    base_index: &AcornHnswIndex,
+pub struct Router<'a> {
+    base: &'a dyn SimilaritySearchable,
+    opportunistic: Vec<(&'a Bitmask, &'a dyn SimilaritySearchable)>,
 }
 
-impl Router {}
+impl<'a> Router<'a> {
+    pub fn new(
+        base: &'a dyn SimilaritySearchable,
+        opportunistic: Vec<(&'a Bitmask, &'a dyn SimilaritySearchable)>,
+    ) -> Self {
+        Router {
+            base,
+            opportunistic,
+        }
+    }
+}
+
+impl SimilaritySearchable for Router<'_> {
+    fn len(&self) -> usize {
+        self.base.len()
+    }
+
+    fn get_dimensionality(&self) -> usize {
+        self.base.get_dimensionality()
+    }
+
+    fn get_metadata(&self) -> &crate::dataset::HybridSearchMetadata {
+        self.base.get_metadata()
+    }
+
+    fn initialize(
+        &mut self,
+        _opts: &crate::dataset::OakIndexOptions,
+    ) -> anyhow::Result<(), crate::dataset::ConstructionError> {
+        // TODO: do we need to do anything in here to optimize bitmask comparisons?
+        Ok(())
+    }
+
+    fn search(
+        &self,
+        query_vectors: &crate::fvecs::FlattenedVecs,
+        predicate_query: &Option<crate::predicate::PredicateQuery>,
+        topk: usize,
+    ) -> anyhow::Result<Vec<crate::dataset::TopKSearchResult>, crate::dataset::SearchableError>
+    {
+        self.base.search(query_vectors, predicate_query, topk)
+    }
+
+    fn search_with_bitmask(
+        &self,
+        query_vectors: &crate::fvecs::FlattenedVecs,
+        query_bitmask: &crate::bitmask::Bitmask,
+        topk: usize,
+    ) -> anyhow::Result<Vec<crate::dataset::TopKSearchResult>, crate::dataset::SearchableError>
+    {
+        let base_meta = self.base.get_metadata();
+        let base_meta_len = base_meta.len();
+
+        let (best_index, best_score) = self
+            .opportunistic
+            .iter()
+            .map(|(opp_mask, opp_index)| {
+                let opp_meta = opp_index.get_metadata();
+                let perf_gain = opp_meta.len() / base_meta_len;
+                let recall_loss = query_bitmask.jaccard_similarity(opp_mask);
+                (perf_gain as f64) / recall_loss
+            })
+            // get the index of the max
+            .enumerate()
+            .max_by(|&(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .unwrap();
+
+        debug!(
+            "The best opportunistic index is at position {} with a score of {}",
+            best_index, best_score
+        );
+
+        let SCORE_THRESHOLD = 1_000_000 as f64;
+
+        let index_to_search = if best_score > SCORE_THRESHOLD {
+            let (_, opp_index) = self.opportunistic[best_index];
+            opp_index
+        } else {
+            self.base
+        };
+
+        index_to_search.search_with_bitmask(query_vectors, query_bitmask, topk)
+    }
+}


### PR DESCRIPTION
Closes #33.

Adds a `Router` that implements `SimilaritySearchable` (the trait renamed from `Dataset`). This implements a very basic (and unvetted) heuristic for choosing an index, which is to multiply the size disparity between the base index and the opportunistic index by the Jaccard index of the query and opportunistic bitmasks.